### PR TITLE
FreeBSD compatibility patch. Fixes the problems:

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,10 @@ AS_CASE([$host_os],
 			libc_name="libc.so.6"
 		fi
 	],
+	[freebsd*],
+	[
+		libc_name=`ldd /usr/bin/yes | grep 'libc\.' | cut -d ' ' -f 3 | tr -d '\t'`
+	],
 	[libc_name="libc.so"]
 )
 AC_DEFINE_UNQUOTED([LIBC_NAME],["${libc_name}"], [Description])

--- a/src/common/compat.h
+++ b/src/common/compat.h
@@ -97,7 +97,7 @@ void tsocks_mutex_unlock(tsocks_mutex_t *m);
 
 #endif /* __linux__ */
 
-#if (defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__darwin__) || defined(__NetBSD__))
+#if (defined(__FreeBSD__) || defined(__darwin__) || defined(__NetBSD__))
 
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -120,7 +120,7 @@ void tsocks_mutex_unlock(tsocks_mutex_t *m);
 #define TSOCKS_NR_FORK      SYS_fork
 #endif
 
-#endif /* __FreeBSD__, __FreeBSD_kernel__, __darwin__, __NetBSD__ */
+#endif /* __FreeBSD__, __darwin__, __NetBSD__ */
 
 #define TSOCKS_CLASSA_NET   0xff000000
 #define TSOCKS_LOOPBACK_NET 0x7f000000

--- a/src/common/compat.h
+++ b/src/common/compat.h
@@ -115,6 +115,10 @@ void tsocks_mutex_unlock(tsocks_mutex_t *m);
 #define TSOCKS_NR_GETPEERNAME SYS_getpeername
 #define TSOCKS_NR_LISTEN    SYS_listen
 #define TSOCKS_NR_RECVMSG   SYS_recvmsg
+#if defined(__FreeBSD__)
+#define TSOCKS_NR_GETPID    SYS_getpid
+#define TSOCKS_NR_FORK      SYS_fork
+#endif
 
 #endif /* __FreeBSD__, __FreeBSD_kernel__, __darwin__, __NetBSD__ */
 

--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -228,6 +228,14 @@ LIBC_SYSCALL_RET_TYPE tsocks_syscall(long int number, va_list args)
 	case TSOCKS_NR_RECVMSG:
 		ret = handle_recvmsg(args);
 		break;
+#if defined(__FreeBSD__)
+	case TSOCKS_NR_FORK:
+		ret = tsocks_libc_syscall(TSOCKS_NR_FORK);
+		break;
+	case TSOCKS_NR_GETPID:
+		ret = tsocks_libc_syscall(TSOCKS_NR_GETPID);
+		break;
+#endif
 	default:
 		/*
 		 * Because of the design of syscall(), we can't pass a va_list to it so

--- a/src/lib/torsocks.h
+++ b/src/lib/torsocks.h
@@ -241,17 +241,6 @@ struct hostent **result, int *h_errnop
 
 #endif /* __FreeBSD__, __darwin__, __NetBSD__ */
 
-#if defined(__GLIBC__) && defined(__FreeBSD_kernel__)
-
-/* syscall(2) */
-#define LIBC_SYSCALL_NAME syscall
-#define LIBC_SYSCALL_NAME_STR XSTR(LIBC_SYSCALL_NAME)
-#define LIBC_SYSCALL_RET_TYPE long int
-#define LIBC_SYSCALL_SIG long int number, ...
-#define LIBC_SYSCALL_ARGS number
-
-#endif /* __GLIBC__ && __FreeBSD_kernel__ */
-
 /* __syscall(2) */
 #if defined(__FreeBSD__)
 


### PR DESCRIPTION
1. fork(2) and getpid(2) are called (by libc?) through syscall(2)
   and torsocks failed them since syscall hook is missing them.
2. The right for dlopen version of libc.so wasn't found by configure script