### PR TITLE
Move handle_sched_getaffinity to linux section

### DIFF
--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -164,6 +164,9 @@ static LIBC_RECVMSG_RET_TYPE handle_recvmsg(va_list args)
 	return tsocks_recvmsg(sockfd, msg, flags);
 }
 
+
+#if defined(__linux__)
+
 /*
  * Handle sched_getaffinity(2) syscall.
  * NOTE: ffmpeg is one of the application that needs this one on the
@@ -183,7 +186,7 @@ static LIBC_SYSCALL_RET_TYPE handle_sched_getaffinity(va_list args)
 			mask);
 }
 
-#if defined(__linux__)
+
 /*
  * Handle gettid(2) syscall.
  */


### PR DESCRIPTION
Trying to compile on OS X (10.11) and `make` fails with:

```
syscall.c:176:2: error: use of undeclared identifier 'cpu_set_t'
        cpu_set_t *mask;
        ^
syscall.c:176:13: error: use of undeclared identifier 'mask'
        cpu_set_t *mask;
                   ^
syscall.c:180:2: error: use of undeclared identifier 'mask'
        mask = va_arg(args, __typeof__(mask));
        ^
syscall.c:180:33: error: use of undeclared identifier 'mask'
        mask = va_arg(args, __typeof__(mask));
                                       ^
syscall.c:182:29: error: use of undeclared identifier 'SYS_sched_getaffinity'
        return tsocks_libc_syscall(TSOCKS_NR_SCHED_GETAFFINITY, pid, cpusetsize,
                                   ^
../../src/common/compat.h:195:37: note: expanded from macro 'TSOCKS_NR_SCHED_GETAFFINITY'
#define TSOCKS_NR_SCHED_GETAFFINITY SYS_sched_getaffinity
                                    ^
syscall.c:183:4: error: use of undeclared identifier 'mask'
                        mask);
```

Moving this call into the `defined(__linux__)` section allows compilation to succeed.