### PR TITLE
gethostbyaddr_r: set result pointer to null on error, per specification

### DIFF
--- a/src/lib/gethostbyname.c
+++ b/src/lib/gethostbyname.c
@@ -310,14 +310,18 @@ LIBC_GETHOSTBYADDR_R_RET_TYPE tsocks_gethostbyaddr_r(LIBC_GETHOSTBYADDR_R_SIG)
 	data->addr_list[1] = NULL;
 	he->h_addr_list = data->addr_list;
 
-	if (result) {
-		*result = he;
-	}
-
 	/* Everything went good. */
 	ret = 0;
 
 error:
+	if (result) {
+		if (ret == 0) {
+			*result = he;
+		} else {
+			*result = NULL;
+		}
+	}
+
 	return ret;
 }
 

--- a/tests/test_dns.c
+++ b/tests/test_dns.c
@@ -95,6 +95,9 @@ static void test_gethostbyaddr_r_failed(void)
 	result = gethostbyaddr_r((const void *)&addr,
 				INET_ADDRSTRLEN, AF_INET, &ret, buf, buflen, &result_entp, &h_errno);
 	ok(0 != result, "Impossible reverse resolve failed as desired.");
+    if (result_entp) {
+        fail("Result pointer should be NULL on failed resolve")
+    }
 }
 
 static void test_gethostbyaddr_r(const struct test_host *host)


### PR DESCRIPTION
`gethostbyaddr_r` should set its `struct hostent **result` parameter to `NULL` on an error ([reference](https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib-gethostbyaddr-r-3.html)). torsocks doesn't do this currently.

python, for example, gets tripped up by this:

```bash
$ torsocks python3 -c 'import socket; socket.getfqdn("127.0.0.1")'
1607419174 ERROR torsocks[3239]: Unable to resolve. Status reply: 4 (in socks5_recv_resolve_ptr_reply() at socks5.c:823)
Segmentation fault
```